### PR TITLE
Removed lorem ipsum from the talks page.

### DIFF
--- a/2012/talks.html
+++ b/2012/talks.html
@@ -48,7 +48,7 @@
     <div class="wrap">&nbsp;</div>
       
     <h3>Keynote</h3>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </p>
+    <p>Charles Oliver Nutter, aka ""The <a href="http://jruby.org/">JRuby</a> Guy" aka <a href="https://twitter.com/#!/headius">@headius</a> will be delivering this year's keynote. Stay tuned for more updates!</p>
   </article>
 </section>
 


### PR DESCRIPTION
I think the lorem ipsum should not be on production website. Added an dummy but relevant text. It can be replaced with "official bio" when the time is ready.
