### PR TITLE
Make Register link open in new page/tab

### DIFF
--- a/2012/badges.html
+++ b/2012/badges.html
@@ -27,7 +27,7 @@
   <nav id="primary">
     <ul>
       <li><a class="index"      href="index.html"   >Home</a></li>
-      <li><a class="register"   href="http://rubyconfindia.doattend.com/">Register</a></li>
+      <li><a class="register"   href="http://rubyconfindia.doattend.com/" target="_blank">Register</a></li>
       <li><a class="talks"      href="talks.html"   >Talks</a></li>
       <li><a class="schedule"   href="schedule.html">Schedule</a></li>
       <li><a class="badges"     href="badges.html"  >Badges</a></li>

--- a/2012/directions.html
+++ b/2012/directions.html
@@ -27,7 +27,7 @@
   <nav id="primary">
     <ul>
       <li><a class="index"      href="index.html"   >Home</a></li>
-      <li><a class="register"   href="http://rubyconfindia.doattend.com/">Register</a></li>
+      <li><a class="register"   href="http://rubyconfindia.doattend.com/" target="_blank">Register</a></li>
       <li><a class="talks"      href="talks.html"   >Talks</a></li>
       <li><a class="schedule"   href="schedule.html">Schedule</a></li>
       <li><a class="badges"     href="badges.html"  >Badges</a></li>

--- a/2012/index.html
+++ b/2012/index.html
@@ -27,7 +27,7 @@
   <nav id="primary">
     <ul>
       <li><a class="index"      href="index.html"   >Home</a></li>
-      <li><a class="register"   href="http://rubyconfindia.doattend.com/">Register</a></li>
+      <li><a class="register"   href="http://rubyconfindia.doattend.com/" target="_blank">Register</a></li>
       <li><a class="talks"      href="talks.html"   >Talks</a></li>
       <li><a class="schedule"   href="schedule.html">Schedule</a></li>
       <li><a class="badges"     href="badges.html"  >Badges</a></li>
@@ -38,7 +38,7 @@
   <section id="index">
   <section id="news">
     <h2>Latest news</h2>
-    <p>Dates for the conference are set at 24th and 25th of March 2012, and <a href="http://rubyconfindia.doattend.com/">the registrations are open!</a></p>
+    <p>Dates for the conference are set at 24th and 25th of March 2012, and <a href="http://rubyconfindia.doattend.com/" target="_blank">the registrations are open!</a></p>
     <h2>Participation Information</h2>
    <p>The call for proposals for talks at RubyConf India 2012 is now closed!</p>
    <p>Selected talks are out, checkout <a href="talks.html">talks page</a> for details.</p>

--- a/2012/schedule.html
+++ b/2012/schedule.html
@@ -27,7 +27,7 @@
   <nav id="primary">
     <ul>
       <li><a class="index"      href="index.html"   >Home</a></li>
-      <li><a class="register"   href="http://rubyconfindia.doattend.com/">Register</a></li>
+      <li><a class="register"   href="http://rubyconfindia.doattend.com/" target="_blank">Register</a></li>
       <li><a class="talks"      href="talks.html"   >Talks</a></li>
       <li><a class="schedule"   href="schedule.html">Schedule</a></li>
       <li><a class="badges"     href="badges.html"  >Badges</a></li>

--- a/2012/talks.html
+++ b/2012/talks.html
@@ -27,7 +27,7 @@
   <nav id="primary">
     <ul>
       <li><a class="index"      href="index.html"   >Home</a></li>
-      <li><a class="register"   href="http://rubyconfindia.doattend.com/">Register</a></li>
+      <li><a class="register"   href="http://rubyconfindia.doattend.com/" target="_blank">Register</a></li>
       <li><a class="talks"      href="talks.html"   >Talks</a></li>
       <li><a class="schedule"   href="schedule.html">Schedule</a></li>
       <li><a class="badges"     href="badges.html"  >Badges</a></li>


### PR DESCRIPTION
set `target="_blank"` for all register links so that user doesn't lose rubyconf page when trying to register
