### PR TITLE
Typo on image file type

### DIFF
--- a/2013/talks.html
+++ b/2013/talks.html
@@ -195,7 +195,7 @@
         </li>
         <li>
           <div class="speaker">
-            <img src="assets/images/speakers/sausheong.png" />
+            <img src="assets/images/speakers/sausheong.jpg" />
             <a href="http://github.com/sausheong">Sau Sheong Chang</a>
           </div>
           <div class="details">


### PR DESCRIPTION
Typo on image file type, did not change .png to .jpg. Please merge this pull request to update the file type.
