### PR TITLE
Responsive Navigation of Menu Items in Navigation

### DIFF
--- a/2014/code.html
+++ b/2014/code.html
@@ -14,6 +14,7 @@
         <header>
             <h1><a href="/2014/">RubyConf <span>India</span></a></h1>
             <nav>
+              <a href="#" id="pull">Menu</a>
               <ul>
                     <li><a href="tickets.html">book Tickets</a></li>
                     <!--<li><a href="https://rubyconfindia2014.busyconf.com/proposals/new">submit a Proposal</a></li>-->

--- a/2014/css/application.css
+++ b/2014/css/application.css
@@ -1241,30 +1241,34 @@ header h3 a:hover {
 nav, .page nav {
   display: block;
   position: absolute;
-  text-align: center;
-  margin: 0;
+  text-align: left;
+  margin: 1%;
   top: 5px;
   left: 0;
   right: 0;
 }
 /* line 10, ../scss/modules/_nav.scss */
+nav a#pull, .page nav a#pull {
+  display: none;
+}
+/* line 14, ../scss/modules/_nav.scss */
 nav ul, .page nav ul {
-  display: inline-block;
   margin: 0;
   padding: 0;
+  width: 27%;
+  list-style: none;
 }
-/* line 15, ../scss/modules/_nav.scss */
+/* line 20, ../scss/modules/_nav.scss */
 nav ul li, .page nav ul li {
-  display: inline-block;
   position: relative;
   margin: 0 0 0 0;
   padding: 0 8px 0 0;
 }
-/* line 21, ../scss/modules/_nav.scss */
+/* line 25, ../scss/modules/_nav.scss */
 nav ul li:before, .page nav ul li:before {
   display: none;
 }
-/* line 23, ../scss/modules/_nav.scss */
+/* line 27, ../scss/modules/_nav.scss */
 nav ul li a, .page nav ul li a {
   color: white;
   display: block;
@@ -1272,12 +1276,39 @@ nav ul li a, .page nav ul li a {
   text-transform: lowercase;
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
 }
-/* line 30, ../scss/modules/_nav.scss */
+/* line 34, ../scss/modules/_nav.scss */
 nav ul li a:hover, .page nav ul li a:hover {
   border-bottom: none;
   text-shadow: 1px 1px 1px white;
 }
 
+@media only screen and (max-width: 600px) {
+  /* line 48, ../scss/modules/_nav.scss */
+  nav {
+    width: 50%;
+  }
+
+  /* line 52, ../scss/modules/_nav.scss */
+  nav ul {
+    display: none;
+    width: 100%;
+  }
+
+  /* line 57, ../scss/modules/_nav.scss */
+  nav a#pull {
+    display: inline;
+  }
+
+  /* line 61, ../scss/modules/_nav.scss */
+  nav:hover {
+    background-color: rgba(45, 164, 204, 0.95);
+    border-radius: 2%;
+  }
+  /* line 64, ../scss/modules/_nav.scss */
+  nav:hover ul {
+    display: block;
+  }
+}
 /* line 2, ../scss/pages/_home.scss */
 .home h1 {
   width: 100%;

--- a/2014/faq.html
+++ b/2014/faq.html
@@ -14,6 +14,7 @@
         <header>
             <h1><a href="/2014/">RubyConf <span>India</span></a></h1>
             <nav>
+              <a href="#" id="pull">Menu</a>
               <ul>
                     <li><a href="tickets.html">book Tickets</a></li>
                     <!--<li><a href="https://rubyconfindia2014.busyconf.com/proposals/new">submit a Proposal</a></li>-->

--- a/2014/index.html
+++ b/2014/index.html
@@ -15,6 +15,7 @@
             <h1><a href="/2014/">RubyConf <span>India</span></a></h1>
 
             <nav>
+              <a href="#" id="pull">Menu</a>
               <ul>
                     <li><a href="#invited-speakers">invited speakers</a></li>
                     <li><a href="#sponsors">sponsors</a></li>

--- a/2014/scss/base/_colors.scss
+++ b/2014/scss/base/_colors.scss
@@ -6,6 +6,7 @@ $gray-xlight: rgba($black, 0.2);
 
 $blue: #2da4cc;
 $blue-light: rgba($blue, 0.8);
+$blue-sea: rgba(#2DA4CC,0.95);
 
 $red: #a00;
 $red-light: rgba($red, 0.8);

--- a/2014/scss/modules/_header.scss
+++ b/2014/scss/modules/_header.scss
@@ -6,7 +6,7 @@ header{
   text-align: center;
   position: relative;
 
-  @media screen and (max-width: 1600px){ background-size: 100% auto; margin-bottom: 12px; }
+  @media screen and (max-width: 1600px) { background-size: 100% auto; margin-bottom: 12px; }
 
   a.github{
     position: absolute; top: 0; right: 0; border: none;

--- a/2014/scss/modules/_nav.scss
+++ b/2014/scss/modules/_nav.scss
@@ -1,19 +1,23 @@
 nav, .page nav{
   display: block;
   position: absolute;
-  text-align: center;
-  margin: 0;
+  text-align: left;
+  margin: 1%;
   top: 5px;
   left: 0;
   right: 0;
 
+  a#pull{
+    display: none;
+  }
+
   ul{
-    display: inline-block;
     margin: 0;
     padding: 0;
+    width: 27%;
+    list-style: none;
 
     li{
-      display: inline-block;
       position: relative;
       margin: 0 0 0 0;
       padding: 0 8px 0 0;
@@ -37,4 +41,28 @@ nav, .page nav{
 
   }
 
+}
+
+@media only screen and (max-width: 600px) {
+
+  nav {
+    width: 50%;
+  }
+
+  nav ul {
+    display: none;
+    width: 100%;
+  }
+
+  nav a#pull {
+    display: inline;
+  }
+
+  nav:hover {
+    background-color: $blue-sea;
+    border-radius: 2%;
+    ul {
+      display: block;
+    }
+  }
 }

--- a/2014/tickets.html
+++ b/2014/tickets.html
@@ -14,6 +14,7 @@
         <header>
             <h1><a href="/2014/">RubyConf <span>India</span></a></h1>
             <nav>
+              <a href="#" id="pull">Menu</a>
               <ul>
                     <li><a href="tickets.html">book Tickets</a></li>
                     <!--<li><a href="https://rubyconfindia2014.busyconf.com/proposals/new">submit a Proposal</a></li>-->


### PR DESCRIPTION
**Changes**
- Moved menu-items/navigation-links to left-aligned by default (we can make this only for mobile phones if required)
- Navigation-links disappear and Menu link appears for screen whose view-port is less than 600px
  *\* On hover over Menu, the navigation links appears with sea-blue background

**Note:** The above Responsive Menu design is something I've seen and is fairly common in many sites these days. We can further customise it to our needs as required, based on feedback. I'd definitely appreciate a feedback on this .
